### PR TITLE
refactor: remove duplicate login path and clean up dead code

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,17 +1,25 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import { loginWithEmailPassword } from './auth.service';
 
-export const authLogin = async (req: Request, res: Response): Promise<void> => {
-    const payload = await loginWithEmailPassword(req.body);
+export const authLogin = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+        const payload = await loginWithEmailPassword(req.body);
 
-    res.status(200).json({
-        success: true,
-        message: 'Login successful',
-        data: payload,
-    });
+        res.status(200).json({
+            success: true,
+            message: 'Login successful',
+            data: payload,
+        });
+    } catch (error) {
+        next(error);
+    }
 };
 
-export const authLogout = async (_req: Request, res: Response): Promise<void> => {
+export const authLogout = async (
+    _req: Request,
+    res: Response,
+    _next: NextFunction
+): Promise<void> => {
     res.status(200).json({
         success: true,
         message: 'Logout successful',

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { comparePassword } from '../../utils/hash';
 import { generateToken } from '../../utils/jwt';
 import { UnauthorizedError } from '../../utils/errors/httpErrors';
-import { userLogin } from '../user/user.service';
+import pool from '../../config/database';
 
 type AuthProvider = 'local' | 'google';
 
@@ -61,7 +61,10 @@ const mapLocalUser = (row: Record<string, unknown>): AuthUser => {
 export const loginWithEmailPassword = async (
     credentials: AuthLoginData
 ): Promise<AuthLoginPayload> => {
-    const rows = await userLogin(credentials);
+    const { rows } = await pool.query(
+        `SELECT id, firstname, lastname, email, username, password FROM users WHERE email = $1`,
+        [credentials.email]
+    );
 
     if (!rows.length) {
         throw new UnauthorizedError('Invalid credentials');

--- a/src/modules/feedback/feedback.routes.ts
+++ b/src/modules/feedback/feedback.routes.ts
@@ -29,6 +29,5 @@ productFeedbackRoute.post('/upvote/:feedbackId', authRateLimit, requireAuth, upv
 
 // comment routes
 productFeedbackRoute.use('/:feedbackId/comments', commentRoute);
-// productFeedbackRoute.post('/:feedbackId/')
 
 export default productFeedbackRoute;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,16 +1,7 @@
 import pool from '../../config/database';
 import { hashPassword } from '../../utils/hash';
 import { randomBytes, createHash } from 'crypto';
-import { UserLogin, UserRegistration } from '../../types/models';
-
-export const userLogin = async (loginData: UserLogin) => {
-    const { email } = loginData;
-    const { rows } = await pool.query(
-        `SELECT id, firstname, lastname, email, username, password FROM users WHERE email = $1`,
-        [email]
-    );
-    return rows;
-};
+import { UserRegistration } from '../../types/models';
 
 export const userRegistration = async (registrationData: UserRegistration) => {
     const { firstname, lastname, email, username, password } = registrationData;


### PR DESCRIPTION
## Summary

- Moves the user DB query directly into `auth.service` and removes the now-redundant `userLogin` export from `user.service` — login responsibility belongs to the auth module
- Adds `try/catch` + `NextFunction` to `auth.controller` handlers for consistency with every other controller in the codebase
- Removes a stale commented-out route line in `feedback.routes.ts`

## Test plan

- [ ] `POST /api/v1/auth/login` with valid credentials returns `{ data: { accessToken, expiresIn, user } }`
- [ ] `POST /api/v1/auth/login` with wrong password returns 401
- [ ] `POST /api/v1/auth/login` with unknown email returns 401 (same message — no user enumeration)
- [ ] `npm run lint` passes with 0 warnings
- [ ] `npx tsc --noEmit` passes