### PR TITLE
feat: add delete own comment endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules
 dist
+notes/

--- a/src/modules/comment/comment.controller.ts
+++ b/src/modules/comment/comment.controller.ts
@@ -2,7 +2,9 @@ import { Request, Response, NextFunction } from 'express';
 import {
     addComment as addCommentService,
     getFeedbackComments as getFeedbackCommentsService,
+    deleteComment as deleteCommentService,
 } from './comment.service';
+import { NotFoundError } from '../../utils/errors/httpErrors';
 
 export const addComment = async function (req: Request, res: Response, next: NextFunction) {
     try {
@@ -33,6 +35,22 @@ export const getFeedbackComments = async function (
             message: 'Comments retrieved successfully',
             data: result,
         });
+    } catch (error) {
+        next(error);
+    }
+};
+
+export const removeComment = async function (req: Request, res: Response, next: NextFunction) {
+    try {
+        const { commentId } = req.params;
+        const userId = req.authUser!.userId;
+        const rowCount = await deleteCommentService(commentId, userId);
+
+        if (rowCount === 0) {
+            throw new NotFoundError('Comment not found');
+        }
+
+        res.status(204).send();
     } catch (error) {
         next(error);
     }

--- a/src/modules/comment/comment.controller.ts
+++ b/src/modules/comment/comment.controller.ts
@@ -4,7 +4,7 @@ import {
     getFeedbackComments as getFeedbackCommentsService,
     deleteComment as deleteCommentService,
 } from './comment.service';
-import { NotFoundError } from '../../utils/errors/httpErrors';
+import { BadRequestError, NotFoundError } from '../../utils/errors/httpErrors';
 
 export const addComment = async function (req: Request, res: Response, next: NextFunction) {
     try {
@@ -42,9 +42,14 @@ export const getFeedbackComments = async function (
 
 export const removeComment = async function (req: Request, res: Response, next: NextFunction) {
     try {
-        const { commentId } = req.params;
+        const { commentId, feedbackId } = req.params;
         const userId = req.authUser!.userId;
-        const rowCount = await deleteCommentService(commentId, userId);
+
+        if (isNaN(Number(commentId))) {
+            throw new BadRequestError('Invalid comment ID');
+        }
+
+        const rowCount = await deleteCommentService(commentId, feedbackId, userId);
 
         if (rowCount === 0) {
             throw new NotFoundError('Comment not found');

--- a/src/modules/comment/comment.routes.ts
+++ b/src/modules/comment/comment.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addComment, getFeedbackComments } from './comment.controller';
+import { addComment, getFeedbackComments, removeComment } from './comment.controller';
 import { requireAuth } from '../../middleware/auth.middleware';
 import { validate } from '../../middleware/validate.middleware';
 import { AddCommentSchema } from './comment.schema';
@@ -8,5 +8,6 @@ const commentRoute = express.Router({ mergeParams: true });
 
 commentRoute.get('/', getFeedbackComments);
 commentRoute.post('/', requireAuth, validate(AddCommentSchema), addComment);
+commentRoute.delete('/:commentId', requireAuth, removeComment);
 
 export default commentRoute;

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -16,3 +16,11 @@ export const getFeedbackComments = async function (feedbackId: string) {
 
     return rows;
 };
+
+export const deleteComment = async function (commentId: string, userId: string) {
+    const { rowCount } = await pool.query('DELETE FROM comments WHERE id = $1 AND user_id = $2', [
+        commentId,
+        userId,
+    ]);
+    return rowCount;
+};

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -17,10 +17,14 @@ export const getFeedbackComments = async function (feedbackId: string) {
     return rows;
 };
 
-export const deleteComment = async function (commentId: string, userId: string) {
-    const { rowCount } = await pool.query('DELETE FROM comments WHERE id = $1 AND user_id = $2', [
-        commentId,
-        userId,
-    ]);
-    return rowCount;
+export const deleteComment = async function (
+    commentId: string,
+    feedbackId: string,
+    userId: string
+) {
+    const { rowCount } = await pool.query(
+        'DELETE FROM comments WHERE id = $1 AND feedback_id=$2 AND user_id = $3',
+        [commentId, feedbackId, userId]
+    );
+    return rowCount ?? 0;
 };


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/v1/feedback/:feedbackId/comments/:commentId`
- Ownership enforced at the DB level — `AND user_id = $2` means only the comment author can delete
- Returns 404 if the comment doesn't exist or belongs to another user
- Returns 204 on success (no body)
- Protected by `requireAuth`